### PR TITLE
Fix for RuntimeError on torch tensor indexing

### DIFF
--- a/pytorch_neat/recurrent_net.py
+++ b/pytorch_neat/recurrent_net.py
@@ -33,7 +33,7 @@ def dense_from_coo(shape, conns, dtype=torch.float64):
     idxs, weights = conns
     if len(idxs) == 0:
         return mat
-    rows, cols = np.array(idxs).transpose()
+    rows, cols = np.array(idxs, dtype=np.int64).transpose()
     mat[torch.tensor(rows), torch.tensor(cols)] = torch.tensor(
         weights, dtype=dtype)
     return mat


### PR DESCRIPTION
This resolves #2
Fix for RuntimeError: tensors used as indices must be long or byte tensors